### PR TITLE
more alignment with coscmic style and theme

### DIFF
--- a/src/app/bottom_bar/gallery_button.rs
+++ b/src/app/bottom_bar/gallery_button.rs
@@ -18,13 +18,23 @@ impl AppModel {
     pub fn build_gallery_button(&self) -> Element<'_, Message> {
         let is_disabled = self.transition_state.ui_disabled;
 
+        // Get corner radius from theme for consistent styling
+        let theme = cosmic::theme::active();
+        let corner_radius = theme.cosmic().corner_radii.radius_s[0];
+
         // If we have both the thumbnail handle and RGBA data, use custom primitive
         let button_content = if let (Some(thumbnail), Some((rgba_data, width, height))) =
             (&self.gallery_thumbnail, &self.gallery_thumbnail_rgba)
         {
             // Use custom GPU primitive with rounded corner clipping
             // Arc::clone is cheap - just increments reference count, doesn't copy image data
-            gallery_widget(thumbnail.clone(), Arc::clone(rgba_data), *width, *height)
+            gallery_widget(
+                thumbnail.clone(),
+                Arc::clone(rgba_data),
+                *width,
+                *height,
+                corner_radius,
+            )
         } else if let Some(thumbnail) = &self.gallery_thumbnail {
             // Fallback: if we only have the handle (shouldn't happen in practice)
             let image = widget::image::Image::new(thumbnail.clone())

--- a/src/app/controls/capture_button.rs
+++ b/src/app/controls/capture_button.rs
@@ -21,6 +21,13 @@ impl AppModel {
         let spacing = cosmic::theme::spacing();
         let is_disabled = self.transition_state.ui_disabled;
 
+        // Get corner radius from theme - use radius_xl for large buttons
+        // Scale it to fit the button (max is half the button size for a circle)
+        let theme = cosmic::theme::active();
+        let theme_radius = theme.cosmic().corner_radii.radius_xl[0];
+        // Cap at half the button size (25.0) for circular appearance when theme is "round"
+        let base_corner_radius = theme_radius.min(ui::CAPTURE_BUTTON_RADIUS);
+
         // Determine button color based on mode and state
         let capture_button_color = if is_disabled {
             Color::from_rgba(0.5, 0.5, 0.5, 0.3) // Grayed out with low opacity when disabled
@@ -68,6 +75,9 @@ impl AppModel {
                 (ui::CAPTURE_BUTTON_INNER, ui::CAPTURE_BUTTON_OUTER)
             };
 
+        // Scale corner radius proportionally when button size changes
+        let corner_radius = base_corner_radius * (inner_size / ui::CAPTURE_BUTTON_INNER);
+
         let button_inner = widget::container(widget::Space::new(
             Length::Fixed(inner_size),
             Length::Fixed(inner_size),
@@ -75,8 +85,7 @@ impl AppModel {
         .style(move |_theme| widget::container::Style {
             background: Some(Background::Color(capture_button_color)),
             border: cosmic::iced::Border {
-                radius: [ui::CAPTURE_BUTTON_RADIUS * (inner_size / ui::CAPTURE_BUTTON_INNER); 4]
-                    .into(),
+                radius: [corner_radius; 4].into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/app/controls/recording_buttons.rs
+++ b/src/app/controls/recording_buttons.rs
@@ -13,10 +13,18 @@ impl AppModel {
     pub fn build_photo_during_recording_button(&self) -> Element<'_, Message> {
         let spacing = cosmic::theme::spacing();
 
+        // Get corner radius from theme - use radius_xl for large buttons
+        let theme = cosmic::theme::active();
+        let theme_radius = theme.cosmic().corner_radii.radius_xl[0];
+        // Cap at half the button size for circular appearance when theme is "round"
+        let base_corner_radius = theme_radius.min(ui::CAPTURE_BUTTON_RADIUS);
+
         let size = ui::CAPTURE_BUTTON_INNER * 0.70;
+        let scale_factor = 0.70;
 
         // White circle with smaller inner circle for photo capture
         let inner_circle_size = size * 0.85;
+        let inner_corner_radius = base_corner_radius * scale_factor * 0.85;
         let button_inner = widget::container(widget::Space::new(
             Length::Fixed(inner_circle_size),
             Length::Fixed(inner_circle_size),
@@ -24,12 +32,13 @@ impl AppModel {
         .style(move |_theme| widget::container::Style {
             background: Some(Background::Color(Color::WHITE)),
             border: cosmic::iced::Border {
-                radius: [ui::CAPTURE_BUTTON_RADIUS * 0.70 * 0.85; 4].into(),
+                radius: [inner_corner_radius; 4].into(),
                 ..Default::default()
             },
             ..Default::default()
         });
 
+        let outer_corner_radius = base_corner_radius * scale_factor;
         let button_outer = widget::container(button_inner)
             .width(Length::Fixed(size))
             .height(Length::Fixed(size))
@@ -38,7 +47,7 @@ impl AppModel {
             .style(move |_theme| widget::container::Style {
                 background: Some(Background::Color(Color::from_rgba(1.0, 1.0, 1.0, 0.3))),
                 border: cosmic::iced::Border {
-                    radius: [ui::CAPTURE_BUTTON_RADIUS * 0.70; 4].into(),
+                    radius: [outer_corner_radius; 4].into(),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/src/app/gallery_widget.rs
+++ b/src/app/gallery_widget.rs
@@ -25,8 +25,10 @@ impl GalleryWidget {
         rgba_data: Arc<Vec<u8>>,
         width: u32,
         height: u32,
+        corner_radius: f32,
     ) -> Self {
-        let primitive = GalleryPrimitive::new(image_handle, rgba_data, width, height);
+        let primitive =
+            GalleryPrimitive::new(image_handle, rgba_data, width, height, corner_radius);
 
         Self {
             primitive,
@@ -85,6 +87,13 @@ pub fn gallery_widget<'a>(
     rgba_data: Arc<Vec<u8>>,
     width: u32,
     height: u32,
+    corner_radius: f32,
 ) -> Element<'a, crate::app::Message, Theme, Renderer> {
-    Element::new(GalleryWidget::new(image_handle, rgba_data, width, height))
+    Element::new(GalleryWidget::new(
+        image_handle,
+        rgba_data,
+        width,
+        height,
+        corner_radius,
+    ))
 }


### PR DESCRIPTION
use checkmark indicator with accent border for current selection of filters. make sure that filter previews, gallery button and capture buttons follow the cosmic style and theme.

closes #84