### PR TITLE
ci: free disk space before builds to prevent out-of-space errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
     name: Check & Test
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -100,6 +111,17 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             use_cross: true
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -147,6 +169,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -187,6 +220,17 @@ jobs:
     # Only run on manual trigger with build_aarch64_flatpak=true
     if: github.event_name == 'workflow_dispatch' && inputs.build_aarch64_flatpak
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -232,6 +276,17 @@ jobs:
     # Only run on manual trigger with build_armhf_flatpak=true
     if: github.event_name == 'workflow_dispatch' && inputs.build_armhf_flatpak
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Add `jlumbroso/free-disk-space` action to all CI jobs to remove unused pre-installed software before building
- Fixes "No space left on device" errors during compilation that are causing all PRs to fail

This removes Android SDK, .NET, Haskell, large packages, Docker images, and swap storage to free up ~30GB of disk space on GitHub Actions runners.

## Test plan
- [ ] CI builds pass without disk space errors