### PR TITLE
fix: Make ioctl calls compatible with musl

### DIFF
--- a/src/backends/camera/pipewire/enumeration.rs
+++ b/src/backends/camera/pipewire/enumeration.rs
@@ -273,7 +273,14 @@ fn get_v4l2_driver(device_path: &str) -> Option<String> {
         reserved: [0; 3],
     };
 
-    let result = unsafe { libc::ioctl(fd, VIDIOC_QUERYCAP, &mut cap as *mut V4l2Capability) };
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_ioctl,
+            fd,
+            VIDIOC_QUERYCAP,
+            &mut cap as *mut V4l2Capability,
+        )
+    };
 
     if result < 0 {
         debug!(device_path, "Failed to query V4L2 capability");

--- a/src/backends/camera/v4l2_controls.rs
+++ b/src/backends/camera/v4l2_controls.rs
@@ -232,7 +232,14 @@ pub fn query_control(device_path: &str, control_id: u32) -> Option<ControlInfo> 
         reserved: [0; 2],
     };
 
-    let result = unsafe { libc::ioctl(fd, VIDIOC_QUERYCTRL, &mut qctrl as *mut V4l2Queryctrl) };
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_ioctl,
+            fd,
+            VIDIOC_QUERYCTRL,
+            &mut qctrl as *mut V4l2Queryctrl,
+        )
+    };
 
     if result < 0 {
         return None;
@@ -260,7 +267,14 @@ pub fn get_control(device_path: &str, control_id: u32) -> Option<i32> {
         value: 0,
     };
 
-    let result = unsafe { libc::ioctl(fd, VIDIOC_G_CTRL, &mut ctrl as *mut V4l2Control) };
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_ioctl,
+            fd,
+            VIDIOC_G_CTRL,
+            &mut ctrl as *mut V4l2Control,
+        )
+    };
 
     if result < 0 {
         debug!(device_path, control_id, "Failed to get V4L2 control");
@@ -280,7 +294,14 @@ pub fn set_control(device_path: &str, control_id: u32, value: i32) -> Result<(),
         value,
     };
 
-    let result = unsafe { libc::ioctl(fd, VIDIOC_S_CTRL, &mut ctrl as *mut V4l2Control) };
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_ioctl,
+            fd,
+            VIDIOC_S_CTRL,
+            &mut ctrl as *mut V4l2Control,
+        )
+    };
 
     if result < 0 {
         let errno = std::io::Error::last_os_error();
@@ -326,7 +347,14 @@ pub fn query_menu_items(device_path: &str, control_id: u32, max_index: i32) -> V
             reserved: 0,
         };
 
-        let result = unsafe { libc::ioctl(fd, VIDIOC_QUERYMENU, &mut qmenu as *mut V4l2Querymenu) };
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_ioctl,
+                fd,
+                VIDIOC_QUERYMENU,
+                &mut qmenu as *mut V4l2Querymenu,
+            )
+        };
 
         if result >= 0 {
             items.push(MenuItem {


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does -->

`ioctl` implementation in glibc takes `unsigned long int`[0]. The musl implementation takes `int`[1]. That causes incompatibility, since the `libc::ioctl` wrapper expects `c_int` on musl targets.

Given that `ioctl` is just a regular syscall handled by the Linux kernel, use `libc::syscall` directly, so we don't have to deal with the integer types.

[0] https://elixir.bootlin.com/glibc/glibc-2.41.9000/source/misc/sys/ioctl.h#L42
[1] https://elixir.bootlin.com/musl/v1.2.5/source/include/stropts.h#L133

## Checklist

<!-- Check all that apply -->

- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] I have added comments for complex logic
- [x] My changes generate no new warnings
