### PR TITLE
Implement camera sensor rotation detection and correction

### DIFF
--- a/src/app/camera_ops.rs
+++ b/src/app/camera_ops.rs
@@ -27,6 +27,7 @@ impl AppModel {
             path: camera_path.clone(),
             metadata_path: camera.metadata_path.clone(),
             device_info: camera.device_info.clone(),
+            rotation: camera.rotation,
         };
         let formats_for_new_mode = backend.get_formats(&device, new_mode == CameraMode::Video);
 
@@ -238,6 +239,7 @@ impl AppModel {
             path: camera_path.clone(),
             metadata_path: camera.metadata_path.clone(),
             device_info: camera.device_info.clone(),
+            rotation: camera.rotation,
         };
         self.available_formats = backend.get_formats(&device, mode == CameraMode::Video);
 

--- a/src/app/handlers/capture.rs
+++ b/src/app/handlers/capture.rs
@@ -726,6 +726,7 @@ impl AppModel {
 
         let device_path = camera.path.clone();
         let metadata_path = camera.metadata_path.clone();
+        let sensor_rotation = camera.rotation;
         let width = format.width;
         let height = format.height;
         let framerate = format.framerate.unwrap_or(30);
@@ -775,6 +776,7 @@ impl AppModel {
                     audio_device.as_deref(),
                     None,
                     selected_encoder.as_ref(),
+                    sensor_rotation,
                 ) {
                     Ok(r) => r,
                     Err(e) => return Err(e),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -717,6 +717,10 @@ impl cosmic::Application for AppModel {
                                 device_info: current_camera
                                     .as_ref()
                                     .and_then(|c| c.device_info.clone()),
+                                rotation: current_camera
+                                    .as_ref()
+                                    .map(|c| c.rotation)
+                                    .unwrap_or_default(),
                             };
 
                             let format = CameraFormat {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -257,6 +257,7 @@ pub fn record_video(
         None, // Use default audio device
         None, // No preview sender needed for CLI
         None, // Auto-select encoder
+        camera.rotation,
     )?;
 
     // Start recording


### PR DESCRIPTION
Some devices, especially phones sometimes have sensors mounted with a rotation. I noticed this while testing PostmarketOS on a OnePlus 6T. This pull request corrects the rotation in the preview, saved image and aspect ratio cropping options.