### PR TITLE
Zero copy frame capture

### DIFF
--- a/src/app/frame_processor/tasks/qr_detector.rs
+++ b/src/app/frame_processor/tasks/qr_detector.rs
@@ -255,7 +255,7 @@ fn downscale_gray(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backends::camera::types::PixelFormat;
+    use crate::backends::camera::types::{FrameData, PixelFormat};
 
     #[test]
     fn test_rgba_to_gray() {
@@ -270,7 +270,7 @@ mod tests {
         let frame = CameraFrame {
             width: 2,
             height: 2,
-            data: Arc::from(data.as_slice()),
+            data: FrameData::Copied(Arc::from(data.as_slice())),
             format: PixelFormat::RGBA,
             stride: 8, // 2 pixels * 4 bytes = 8 bytes per row
             captured_at: std::time::Instant::now(),

--- a/src/app/video_primitive.rs
+++ b/src/app/video_primitive.rs
@@ -8,6 +8,7 @@
 //! - Persistent textures across frames
 
 use crate::app::state::FilterType;
+use crate::backends::camera::types::FrameData;
 use cosmic::iced::Rectangle;
 use cosmic::iced_wgpu::graphics::Viewport;
 use cosmic::iced_wgpu::primitive::{self, Primitive as PrimitiveTrait};
@@ -20,8 +21,8 @@ pub struct VideoFrame {
     pub id: u64,
     pub width: u32,
     pub height: u32,
-    // Frame data buffer (shared Arc - no copy, RGBA format)
-    pub data: Arc<[u8]>,
+    // Frame data buffer (zero-copy when from GStreamer, RGBA format)
+    pub data: FrameData,
     // Row stride for RGBA data (bytes per row including padding)
     pub stride: u32,
 }
@@ -30,7 +31,7 @@ impl VideoFrame {
     /// Get RGBA data slice
     #[inline]
     pub fn rgba_data(&self) -> &[u8] {
-        &self.data[..]
+        &self.data
     }
 }
 

--- a/src/app/video_widget.rs
+++ b/src/app/video_widget.rs
@@ -82,7 +82,7 @@ impl VideoWidget {
         };
 
         // Create VideoFrame for RGBA format
-        // IMPORTANT: We share the Arc without copying to avoid ~3MB copy per frame
+        // IMPORTANT: We share the FrameData without copying to maintain zero-copy from GStreamer
         if frame.width > 0 && frame.height > 0 {
             let stride = if frame.stride > 0 {
                 frame.stride
@@ -94,7 +94,7 @@ impl VideoWidget {
                 id: video_id,
                 width: frame.width,
                 height: frame.height,
-                data: Arc::clone(&frame.data), // No copy - just increment refcount
+                data: frame.data.clone(), // Clone FrameData - just refcount increment, no data copy
                 stride,
             };
 

--- a/src/backends/virtual_camera/file_source.rs
+++ b/src/backends/virtual_camera/file_source.rs
@@ -6,7 +6,9 @@
 //! for use with the virtual camera output. Videos also stream audio
 //! to a virtual microphone via PipeWire.
 
-use crate::backends::camera::types::{BackendError, BackendResult, CameraFrame, PixelFormat};
+use crate::backends::camera::types::{
+    BackendError, BackendResult, CameraFrame, FrameData, PixelFormat,
+};
 use crate::constants::{file_formats, virtual_camera as vc_timing};
 use std::path::Path;
 use std::sync::Arc;
@@ -201,7 +203,7 @@ fn extract_frame_from_sample(sample: &gstreamer::Sample) -> BackendResult<Camera
     let data: Vec<u8> = map.as_slice().to_vec();
 
     Ok(CameraFrame {
-        data: Arc::from(data.into_boxed_slice()),
+        data: FrameData::Copied(Arc::from(data.into_boxed_slice())),
         width,
         height,
         stride: width * 4,
@@ -289,7 +291,7 @@ pub fn load_image_as_frame(path: &Path) -> BackendResult<CameraFrame> {
     info!(width, height, "Image loaded successfully");
 
     Ok(CameraFrame {
-        data: Arc::from(data.into_boxed_slice()),
+        data: FrameData::Copied(Arc::from(data.into_boxed_slice())),
         width,
         height,
         stride: width * 4, // RGBA = 4 bytes per pixel
@@ -508,7 +510,7 @@ impl VideoDecoder {
         let data: Vec<u8> = map.as_slice().to_vec();
 
         Some(CameraFrame {
-            data: Arc::from(data.into_boxed_slice()),
+            data: FrameData::Copied(Arc::from(data.into_boxed_slice())),
             width: self.width,
             height: self.height,
             stride: self.width * 4,

--- a/src/backends/virtual_camera/mod.rs
+++ b/src/backends/virtual_camera/mod.rs
@@ -247,7 +247,7 @@ impl VirtualCameraManager {
 
         // If stride matches expected row size and no flip needed, use data directly
         if stride == row_bytes && !self.flip_horizontal {
-            return pipeline.push_frame_rgba(Arc::clone(&frame.data), frame.width, frame.height);
+            return pipeline.push_frame_rgba(frame.data.clone(), frame.width, frame.height);
         }
 
         // Copy data (and apply horizontal flip if needed)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -485,7 +485,7 @@ fn is_supported_image(path: &PathBuf) -> bool {
 
 /// Load a DNG file and convert to RGBA CameraFrame
 fn load_dng_frame(path: &PathBuf) -> Result<CameraFrame, Box<dyn std::error::Error>> {
-    use camera::backends::camera::types::{CameraFrame, PixelFormat};
+    use camera::backends::camera::types::{CameraFrame, FrameData, PixelFormat};
     use image::GenericImageView;
     use std::fs::File;
     use std::io::BufReader;
@@ -499,7 +499,7 @@ fn load_dng_frame(path: &PathBuf) -> Result<CameraFrame, Box<dyn std::error::Err
 
     let (width, height) = img.dimensions();
     let rgba = img.to_rgba8();
-    let data: Arc<[u8]> = Arc::from(rgba.into_raw().into_boxed_slice());
+    let data = FrameData::Copied(Arc::from(rgba.into_raw().into_boxed_slice()));
 
     Ok(CameraFrame {
         width,
@@ -515,7 +515,7 @@ fn load_dng_frame(path: &PathBuf) -> Result<CameraFrame, Box<dyn std::error::Err
 fn load_burst_mode_frames(
     paths: &[PathBuf],
 ) -> Result<Vec<Arc<CameraFrame>>, Box<dyn std::error::Error>> {
-    use camera::backends::camera::types::{CameraFrame, PixelFormat};
+    use camera::backends::camera::types::{CameraFrame, FrameData, PixelFormat};
     use image::GenericImageView;
 
     let mut frames = Vec::new();
@@ -532,7 +532,7 @@ fn load_burst_mode_frames(
             let img = image::open(path)?;
             let (width, height) = img.dimensions();
             let rgba = img.to_rgba8();
-            let data: Arc<[u8]> = Arc::from(rgba.into_raw().into_boxed_slice());
+            let data = FrameData::Copied(Arc::from(rgba.into_raw().into_boxed_slice()));
 
             CameraFrame {
                 width,

--- a/src/pipelines/photo/capture.rs
+++ b/src/pipelines/photo/capture.rs
@@ -106,14 +106,14 @@ impl PhotoCapture {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backends::camera::types::PixelFormat;
+    use crate::backends::camera::types::{FrameData, PixelFormat};
 
     #[test]
     fn test_capture_from_frame() {
         let frame = CameraFrame {
             width: 1920,
             height: 1080,
-            data: Arc::from(vec![0u8; 1920 * 1080 * 4]), // RGBA size (4 bytes per pixel)
+            data: FrameData::Copied(Arc::from(vec![0u8; 1920 * 1080 * 4].into_boxed_slice())), // RGBA size (4 bytes per pixel)
             format: PixelFormat::RGBA,
             stride: 1920 * 4, // RGBA stride
             captured_at: std::time::Instant::now(),

--- a/src/pipelines/video/recorder.rs
+++ b/src/pipelines/video/recorder.rs
@@ -10,11 +10,12 @@
 
 use super::encoder_selection::{EncoderConfig, select_encoders};
 use super::muxer::{create_muxer, link_audio_to_muxer, link_muxer_to_sink, link_video_to_muxer};
-use crate::backends::camera::types::{CameraFrame, SensorRotation};
+use crate::backends::camera::types::{CameraFrame, FrameData, SensorRotation};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
 /// Video recorder using the new pipeline architecture
@@ -574,7 +575,9 @@ impl VideoRecorder {
                                         let stride = video_info.stride()[0] as u32;
 
                                         let frame = CameraFrame {
-                                            data: map.as_slice().to_vec().into(),
+                                            data: FrameData::Copied(Arc::from(
+                                                map.as_slice().to_vec().into_boxed_slice(),
+                                            )),
                                             width: video_info.width(),
                                             height: video_info.height(),
                                             format:


### PR DESCRIPTION
| Copy | Baseline | Zero-copy | Improvement |
|------|----------|-----------|-------------|
| Pipeline (`copy_ms`) | ~22ms | 0.00ms | eliminated |
| GPU upload (`gpu_upload_ms`) | ~8ms | ~8ms | unchanged, but can be improved with DMA-BUF |
| **Total** | ~30ms | ~8ms | **~73% faster** |

The GPU upload is faster (~8ms) than the CPU copy was (~22ms) because GPU memory bandwidth is higher.