### PR TITLE
ci: regenerate preview screenshots via pull request

### DIFF
--- a/.github/workflows/regenerate-previews.yml
+++ b/.github/workflows/regenerate-previews.yml
@@ -64,9 +64,13 @@ jobs:
 
       - name: Load udmabuf
         # The fake camera allocates its frame buffers through /dev/udmabuf. The
-        # container opens the node as the mapped (non-root) user, so it has to be
-        # world-accessible; without it the app renders an empty preview.
+        # hosted runner's base kernel package does not ship the udmabuf module,
+        # so pull the matching linux-modules-extra package before loading it. The
+        # container opens the node as the mapped (non-root) user, so it also has
+        # to be world-accessible; without it the app renders an empty preview.
         run: |
+          sudo apt-get update
+          sudo apt-get install -y "linux-modules-extra-$(uname -r)"
           sudo modprobe udmabuf
           sudo chmod 0666 /dev/udmabuf
           test -e /dev/udmabuf


### PR DESCRIPTION
Adds a workflow that keeps the committed preview screenshots in sync with the UI after it changes on main.

It is the sibling of "Regenerate Derived Files", but it cannot push to main the way that job does: the screenshots are rendered in the pinned container and can only be signed off by a human looking at the images, so a regenerated set is proposed as a pull request instead of committed straight to the branch.

## What it does
- Triggers on push to main for the inputs that affect screenshots (src, the preview harness, Cargo.lock, i18n) plus workflow_dispatch. It lists only inputs, never the PNG outputs, so merging its own PR does not retrigger it.
- Renders every shot in the pinned container via just generate-previews, pixel-compares against the committed PNGs, and overwrites only what changed.
- Opens or updates a single PR (branch ci/regenerate-previews) via peter-evans/create-pull-request, scoped to preview/. If nothing changed, no PR is opened.

## Notes
- The capture harness needs /dev/udmabuf, whose module is absent from the hosted runner's base kernel package, so the job installs linux-modules-extra-$(uname -r) before loading it.
- PRs opened by GITHUB_TOKEN do not trigger further workflows, so the generated PR gets no CI checks. That is fine for an images-only PR reviewed by eye.